### PR TITLE
Bump vault-oidc-auth version

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ to provide short-lived credentials for accessing Vault and AWS. Example:
 steps:
   - command: ./run_build.sh
     plugins:
-      - planetscale/vault-oidc-auth#v1.0.0:
+      - planetscale/vault-oidc-auth#v1.1.1:
           vault_addr: "https://my-vault-server"
       - planetscale/vault-aws-creds#v1.0.0:
           vault_addr: "https://my-vault-server"


### PR DESCRIPTION
Brings in the changes from planetscale/vault-oidc-auth-buildkite-plugin#29 to send the organization ID as a JWT claim.